### PR TITLE
Updated experimental factor validation logic and message.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>uk.ac.ebi.pride.maven</groupId>
         <artifactId>pride-base-master</artifactId>
-        <version>1.0.4</version>
+        <version>1.0.5</version>
     </parent>
 
     <licenses>


### PR DESCRIPTION
This fixes a bug with the PX Submission Tool PLIBT-116, which currently allows result files to be annotated with an Experimental Factor >500 characters. This should be properly prevented, as it should be doing so, but isn't working previously.